### PR TITLE
feat: Convert directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,16 @@
 
 Convert vectors in GPlates to vectors in SVGs.
 
-This project is currently in `alpha`. It is very annoying to use, but you can get useful results if:
+GPML-to-SVG is currently in `alpha`. It is very annoying to use, but you can get useful results if:
 
-- you're converting a file with no transformations
 - you know which files you want to convert
 - the shapes you are trying to convert are `SHAPES` according to GPlates and not lines or dots. _Continental Crust_ and _Ocean Crust_ are safe bets.
 
 
 **To use:**
 1. install Node v20.1.0 or higher 
-2. clone the project locally
-3. navigate into the project directory
+2. clone GPML-to-SVG locally
+3. navigate into the GPML-to-SVG directory
 4. run `npm install`
 5. run `npm run build`
 
@@ -26,7 +25,7 @@ where  `<FULL PATH>` is the complete path to the target file,
 
 and `<TIME>` is the moment in the model when all the shapes you want converted exist.
 
-`node dist/index.js convert <FULL PATH> -c "<COLOR>" -t <TIME>`
+`node dist/index.js convert -c "<COLOR>" -t <TIME> <FULL PATH>`
 
 ### Example:
 FULL PATH: `/Users/imauser/folderName/Big\ continents:dinosaur\ friendly.gpml`
@@ -35,7 +34,11 @@ COLOR: `teal` or `008080` or `#008080`
 
 TIME: 900
 
-`node dist/index.js convert /Users/imauser/folderName/Big\ continents:dinosaur\ friendly.gpml -c "008080" -t 900`
+`node dist/index.js convert -c "008080" -t 900 /Users/imauser/folderName/Big\ continents:dinosaur\ friendly.gpml`
+
+You can convert multiple files into one SVG.
+
+`node dist/index.js convert -c "008080" -t 900 /Users/imauser/folderName/Big\ continents:dinosaur\ friendly.gpml /Users/imauser/folderName/Big\ continents:terror\  bird.gpml`
 
 -----------
 I don't have a PC, so if anyone is willing to test this on a PC, I would appreciate the collaboration.

--- a/README.md
+++ b/README.md
@@ -10,16 +10,18 @@ GPML-to-SVG is currently in `alpha`. It is very annoying to use, but you can get
 
 
 **To use:**
-1. install Node v20.1.0 or higher 
+1. install Node v20.1.0 or higher: [How to install Node](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs)
 2. clone GPML-to-SVG locally
 3. navigate into the GPML-to-SVG directory
 4. run `npm install`
 5. run `npm run build`
 
 
-To run the conversion, navigate to the project folder locally and run this command, 
+To run the conversion, navigate to the project folder locally and run the `convert` command, 
 
 where  `<FULL PATH>` is the complete path to the target file, 
+
+where  `<DESTINATION DIRECTORY>` is the complete path to the target destination folder, 
 
 `<COLOR>` is a valid CSS color name or HEX value (keep the double quotes), 
 
@@ -27,10 +29,14 @@ and `<TIME>` is the moment in the model when all the shapes you want converted e
 
 `<ROTATION FILE>` is an optional parameter if you want to specify a rotation file in a different location than any of the directories you list. Otherwise the CLI will look for a rotation file near files you have added as parameters.
 
-`node dist/index.js convert -c "<COLOR>" -t <TIME> <FULL PATH>`
+**The path or paths you want to convert *MUST* come last.**
+
+`node dist/index.js convert -d <DESTINATION DIRECTORY> -c "<COLOR>" -t <TIME> <FULL PATH>`
 
 ### Example:
 FULL PATH: `/Users/imauser/folderName/Big\ continents:dinosaur\ friendly.gpml`
+
+DESTINATION PATH: `/Users/imauser/testTheCode/`
 
 COLOR: `teal` or `008080` or `#008080`
 
@@ -38,11 +44,25 @@ TIME: 900
 
 ROTATION FILE: `/Users/imauser/folderName/shared.rot`
 
-`node dist/index.js convert -c "008080" -t 900 /Users/imauser/folderName/Big\ continents:dinosaur\ friendly.gpml`
+`node dist/index.js convert -d /Users/imauser/testTheCode/-c "008080" -t 900 /Users/imauser/folderName/Big\ continents:dinosaur\ friendly.gpml`
 
 You can convert multiple files into one SVG.
 
 `node dist/index.js convert -c "008080" -t 900 -r /Users/imauser/folderName/shared.rot /Users/imauser/folderName/Big\ continents:dinosaur\ friendly.gpml /Users/imauser/folderName/Big\ continents:terror\  bird.gpml`
+
+or a directory.
+
+`node dist/index.js convert -c "008080" -t 900 -r /Users/imauser/folderName/shared.rot /Users/imauser/folderName`
+
+or combinations
+
+`node dist/index.js convert -c "008080" -t 900 -r /Users/imauser/folderName/shared.rot /Users/imauser/folderName /Users/imauser/folderName2/bigDino.gpml`
+
+### Limitations
+As of this version (0.0.1 super alpha) 
+- only shapes and lines will get converted
+- every file gets converted to a `<g>` group, which can be selected as a group by Illustrator
+- sadly, everything gets the same color
 
 -----------
 I don't have a PC, so if anyone is willing to test this on a PC, I would appreciate the collaboration.

--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ COLOR: `teal` or `008080` or `#008080`
 
 TIME: 900
 
+ROTATION FILE: `/Users/imauser/folderName/shared.rot`
+
 `node dist/index.js convert -c "008080" -t 900 /Users/imauser/folderName/Big\ continents:dinosaur\ friendly.gpml`
 
 You can convert multiple files into one SVG.
 
-`node dist/index.js convert -c "008080" -t 900 /Users/imauser/folderName/Big\ continents:dinosaur\ friendly.gpml /Users/imauser/folderName/Big\ continents:terror\  bird.gpml`
+`node dist/index.js convert -c "008080" -t 900 -r /Users/imauser/folderName/shared.rot /Users/imauser/folderName/Big\ continents:dinosaur\ friendly.gpml /Users/imauser/folderName/Big\ continents:terror\  bird.gpml`
 
 -----------
 I don't have a PC, so if anyone is willing to test this on a PC, I would appreciate the collaboration.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ where  `<FULL PATH>` is the complete path to the target file,
 
 and `<TIME>` is the moment in the model when all the shapes you want converted exist.
 
+`<ROTATION FILE>` is an optional parameter if you want to specify a rotation file in a different location than any of the directories you list. Otherwise the CLI will look for a rotation file near files you have added as parameters.
+
 `node dist/index.js convert -c "<COLOR>" -t <TIME> <FULL PATH>`
 
 ### Example:

--- a/src/GPLATES_CONSTANTS.ts
+++ b/src/GPLATES_CONSTANTS.ts
@@ -2,3 +2,5 @@ export const GPLATES_WIDTH = 1447;
 export const GPLATES_HEIGHT = 761;
 export const GPLATES_X_OFFSET = GPLATES_WIDTH / 2;
 export const GPLATES_Y_OFFSET = GPLATES_HEIGHT / 2;
+
+export const GPLATES_GPML_FILE_EXT = '.gpml';

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -1,0 +1,9 @@
+import { OptionValues } from 'commander';
+import { lstatSync } from 'node:fs';
+
+export const isDirectory = (path: string) =>
+  lstatSync(path) ? lstatSync(path).isDirectory() : false;
+
+export async function convert(filepath: string[], options: OptionValues) {
+  console.log('convert!', { filepath }, Array.isArray(filepath));
+}

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -3,18 +3,34 @@ import { OptionValues } from 'commander';
 
 import colorProcessing from '@utilities/colorProcessing';
 import { findValidRotationFile } from '@modules/validFiles/findValidRotationFile';
+import { parseRotationFile } from '@modules/parseRotation/parseRotationFile';
+import { findRotationTimes } from '@modules/parseRotation/findRotationTimes';
+import { convertFile } from './convertFile';
 
 export async function convert(filepaths: string[], options: OptionValues) {
   // process options
   const color = colorProcessing(options.color.toLowerCase()) || 'black';
   const validFiles = findValidFiles(filepaths);
+  const timeInt = parseInt(options.time);
 
   if (validFiles === undefined) {
     throw Error('No valid files found.');
   }
 
   const { files, rotations } = validFiles;
-  const rotationFile = findValidRotationFile(options.rotationFile, rotations);
+  const rotationFilePath = findValidRotationFile(
+    options.rotationFile,
+    rotations,
+  );
 
-  console.log({ files, rotations }, rotationFile);
+  const rotationDict = parseRotationFile(rotationFilePath);
+  const rotationTimes = findRotationTimes(rotationDict, timeInt);
+
+  const processedFiles = await Promise.allSettled(
+    files.map(async (filePath) => {
+      return convertFile(filePath, rotationTimes, color, timeInt);
+    }),
+  );
+
+  console.log(processedFiles);
 }

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -1,9 +1,9 @@
+import { findValidFiles } from '@modules/validFiles/findValidFiles';
 import { OptionValues } from 'commander';
-import { lstatSync } from 'node:fs';
 
-export const isDirectory = (path: string) =>
-  lstatSync(path) ? lstatSync(path).isDirectory() : false;
+export async function convert(filepaths: string[], options: OptionValues) {
+  console.log('convert!', { filepaths }, Array.isArray(filepaths));
+  const validFiles = findValidFiles(filepaths);
 
-export async function convert(filepath: string[], options: OptionValues) {
-  console.log('convert!', { filepath }, Array.isArray(filepath));
+  console.log({ validFiles });
 }

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -1,9 +1,20 @@
 import { findValidFiles } from '@modules/validFiles/findValidFiles';
 import { OptionValues } from 'commander';
 
+import colorProcessing from '@utilities/colorProcessing';
+import { findValidRotationFile } from '@modules/validFiles/findValidRotationFile';
+
 export async function convert(filepaths: string[], options: OptionValues) {
-  console.log('convert!', { filepaths }, Array.isArray(filepaths));
+  // process options
+  const color = colorProcessing(options.color.toLowerCase()) || 'black';
   const validFiles = findValidFiles(filepaths);
 
-  console.log({ validFiles });
+  if (validFiles === undefined) {
+    throw Error('No valid files found.');
+  }
+
+  const { files, rotations } = validFiles;
+  const rotationFile = findValidRotationFile(options.rotationFile, rotations);
+
+  console.log({ files, rotations }, rotationFile);
 }

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -6,10 +6,8 @@ import { findValidRotationFile } from '@modules/validFiles/findValidRotationFile
 import { parseRotationFile } from '@modules/parseRotation/parseRotationFile';
 import { findRotationTimes } from '@modules/parseRotation/findRotationTimes';
 import { convertFileToGroup } from '../modules/convertFileToGroup.ts/convertFileToGroup';
-
-const isRejected = (
-  input: PromiseSettledResult<unknown>,
-): input is PromiseRejectedResult => input.status === 'rejected';
+import { validDestination } from '@modules/validDestination/validDestination';
+import createSvg from '@modules/createSvg/createSvg';
 
 const isFulfilled = <T>(
   input: PromiseSettledResult<T>,
@@ -17,6 +15,11 @@ const isFulfilled = <T>(
 
 export async function convert(filepaths: string[], options: OptionValues) {
   // process options
+  const { destination } = options;
+  if (!validDestination(destination)) {
+    return 1;
+  }
+
   const color = colorProcessing(options.color.toLowerCase()) || 'black';
   const validFiles = findValidFiles(filepaths);
   const timeInt = parseInt(options.time);
@@ -49,5 +52,5 @@ export async function convert(filepaths: string[], options: OptionValues) {
     )
     .join('\n');
 
-  console.log({ finalElements });
+  createSvg(finalElements, destination);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,9 +21,9 @@ program
     'point in time that a feature must exist',
   )
   .option('-c, --color <string>', 'fill color', 'teal')
-  .argument('<source...>')
-  .action(async (source, options) => {
-    convert(source, options);
+  .argument('<filepaths...>')
+  .action(async (filepaths, options) => {
+    convert(filepaths, options);
   });
 
 program.parse(process.argv);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
+import { convert } from '@commands/convert';
 import { Command } from 'commander';
-
-import { convertFile } from '@commands/convertFile';
 
 import * as dotenv from 'dotenv';
 dotenv.config({ path: __dirname + '/../.env' });
@@ -13,15 +12,18 @@ program.enablePositionalOptions().option('-p, --progress');
 
 program
   .version('0.0.1')
-  .description('A CLI for converting GPLates GPML files to SVGs.')
-  .command('convert <source>')
+  .description('A CLI for converting GPLates GPML files to SVGs.');
+
+program
+  .command('convert')
   .requiredOption(
     '-t, --time <number>',
     'point in time that a feature must exist',
   )
   .option('-c, --color <string>', 'fill color', 'teal')
+  .argument('<source...>')
   .action(async (source, options) => {
-    convertFile(source, options);
+    convert(source, options);
   });
 
 program.parse(process.argv);

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ program
     'point in time that a feature must exist',
   )
   .option('-c, --color <string>', 'fill color', 'teal')
+  .option('-r, --rotation-file <string>', 'path to the rotation file')
   .argument('<filepaths...>')
   .action(async (filepaths, options) => {
     convert(filepaths, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ program
     '-t, --time <number>',
     'point in time that a feature must exist',
   )
+  .requiredOption('-d, --destination <string>', 'where to save the svg')
   .option('-c, --color <string>', 'fill color', 'teal')
   .option('-r, --rotation-file <string>', 'path to the rotation file')
   .argument('<filepaths...>')

--- a/src/modules/convertFileToGroup.ts/convertFileToGroup.ts
+++ b/src/modules/convertFileToGroup.ts/convertFileToGroup.ts
@@ -7,7 +7,7 @@ import { FeatureCollection } from '@projectTypes/timeTypes';
 import { featureAndRotationFactory } from '@modules/featureAndRotation/featureAndRotationFactory';
 import { RotationRecord } from '@projectTypes/rotationTypes';
 
-export async function convertFile(
+export async function convertFileToGroup(
   filepath: string,
   rotationTimes: RotationRecord,
   color: string,

--- a/src/modules/createSvg/createSvg.ts
+++ b/src/modules/createSvg/createSvg.ts
@@ -4,12 +4,7 @@ import errorProcessing from '@utilities/errorProcessing';
 const svgHeader = `<svg width="360" height="180" xmlns="http://www.w3.org/2000/svg">`;
 const svgFooter = '</svg>';
 
-async function createSvg(
-  featureString: string,
-  destPath: string,
-  color?: string,
-) {
-  color = color || '#000000';
+async function createSvg(featureString: string, destPath: string) {
   const content = `${svgHeader}${featureString}${svgFooter}`;
   await fs
     .mkdir(destPath, { recursive: true })

--- a/src/modules/featureAndRotation/featureAndRotationFactory.ts
+++ b/src/modules/featureAndRotation/featureAndRotationFactory.ts
@@ -64,14 +64,20 @@ export function featureAndRotationFactory(
   color: string,
 ) {
   return function (feature: FeatureCollection) {
-    const plateId = feature.reconstructionPlateId.ConstantValue.value;
+    const plateId = feature.reconstructionPlateId?.ConstantValue?.value;
     const rotationNode: RotationNode = rotationTimes[plateId] as RotationNode;
 
-    const finalRotation: Quaternion = findFinalRotation(
-      rotationNode,
-      rotationTimes,
-    );
+    if (plateId) {
+      try {
+        const finalRotation: Quaternion = findFinalRotation(
+          rotationNode,
+          rotationTimes,
+        );
 
-    return parsePoints(feature, color, finalRotation);
+        return parsePoints(feature, color, finalRotation);
+      } catch (e) {
+        console.log(e, feature.reconstructionPlateId);
+      }
+    }
   };
 }

--- a/src/modules/findNodes/parseToJson.ts
+++ b/src/modules/findNodes/parseToJson.ts
@@ -20,7 +20,9 @@ export async function parseToJson(
       }
     }
 
-    throw new Error('No FeatureCollection found');
+    // throw new Error(`No FeatureCollection found in ${sourcePath}`);
+    console.warn(`No FeatureCollection found in ${sourcePath}`);
+    return;
   } catch (err: unknown) {
     errorProcessing(err);
   }

--- a/src/modules/validDestination/validDestination.ts
+++ b/src/modules/validDestination/validDestination.ts
@@ -1,0 +1,16 @@
+import { isDirectory } from '@utilities/isDirectory';
+
+export function validDestination(candidate: string): boolean {
+  if (!candidate.length) {
+    console.log(`No destination provided. Aborting.`);
+    return false;
+  }
+
+  if (isDirectory(candidate)) {
+    console.log(`Using ${candidate} for destination location.`);
+    return true;
+  }
+
+  console.log(`Destination ${candidate} is not a valid directory. Aborting.`);
+  return false;
+}

--- a/src/modules/validFiles/findValidFiles.ts
+++ b/src/modules/validFiles/findValidFiles.ts
@@ -57,11 +57,10 @@ export function findValidFiles(
   if (directories.length) {
     console.log('converted directories', { directories });
 
-    // messaging to human
+    // TODO: messaging to humans
   }
 
   if (files.length) {
-    console.log('files to convert');
     const filesSet = Array.from(new Set(files));
     const rotationSet = Array.from(new Set(rotations));
     return {

--- a/src/modules/validFiles/findValidFiles.ts
+++ b/src/modules/validFiles/findValidFiles.ts
@@ -1,0 +1,56 @@
+import path from 'path';
+import { GPLATES_GPML_FILE_EXT } from 'GPLATES_CONSTANTS';
+import { lstatSync } from 'fs';
+
+export const isDirectory = (path: string) => {
+  try {
+    return lstatSync(path) ? lstatSync(path).isDirectory() : false;
+  } catch {
+    return false;
+  }
+};
+
+export const isFile = (path: string) => {
+  try {
+    return lstatSync(path) ? lstatSync(path).isFile() : false;
+  } catch {
+    return false;
+  }
+};
+
+export function findValidFiles(filepaths: string[]): string[] | undefined {
+  const { files, directories } = filepaths.reduce(
+    (acc, path) => {
+      if (isDirectory(path)) {
+        acc.directories.push(path);
+      } else if (isFile(path)) {
+        acc.files.push(path);
+      }
+
+      return acc;
+    },
+    { files: [] as string[], directories: [] as string[] },
+  );
+
+  if (!directories.length && !files.length) {
+    console.log('nothing to convert');
+  }
+
+  if (directories.length) {
+    console.log('convert directories');
+
+    // add all valid files to files array
+  }
+
+  if (files.length) {
+    console.log('convert files');
+
+    const validFiles = files.filter((filename) => {
+      console.log(path.extname(filename));
+      return path.extname(filename) === GPLATES_GPML_FILE_EXT;
+    });
+    return validFiles;
+  }
+
+  return;
+}

--- a/src/modules/validFiles/findValidRotationFile.ts
+++ b/src/modules/validFiles/findValidRotationFile.ts
@@ -1,0 +1,28 @@
+import { validRotationFile } from '@utilities/validRotationFile';
+
+export function findValidRotationFile(
+  optionRotationFile?: string,
+  rotations?: string[],
+) {
+  let rotationFile: string = '';
+
+  const userRotationFile = validRotationFile(optionRotationFile || '');
+  if (userRotationFile) {
+    rotationFile = userRotationFile;
+  } else if (optionRotationFile) {
+    console.warn(
+      `User defined rotation file: "${optionRotationFile}" is not a valid rotation file.`,
+    );
+  }
+
+  if (!userRotationFile) {
+    if (rotations?.length) {
+      rotationFile = rotations[0];
+      console.warn(`Using found file: "${rotationFile}" as rotation file.`);
+    } else {
+      console.warn('No valid rotation files found near source files.');
+    }
+  }
+
+  return rotationFile;
+}

--- a/src/utilities/isDirectory.ts
+++ b/src/utilities/isDirectory.ts
@@ -1,0 +1,9 @@
+import { lstatSync } from 'fs';
+
+export const isDirectory = (path: string) => {
+  try {
+    return lstatSync(path) ? lstatSync(path).isDirectory() : false;
+  } catch {
+    return false;
+  }
+};

--- a/src/utilities/isFile.ts
+++ b/src/utilities/isFile.ts
@@ -1,0 +1,9 @@
+import { lstatSync } from 'fs';
+
+export const isFile = (path: string) => {
+  try {
+    return lstatSync(path) ? lstatSync(path).isFile() : false;
+  } catch {
+    return false;
+  }
+};

--- a/src/utilities/validRotationFile.ts
+++ b/src/utilities/validRotationFile.ts
@@ -1,0 +1,22 @@
+import { readdirSync } from 'fs';
+import path from 'path';
+import { isFile } from './isFile';
+import { isDirectory } from './isDirectory';
+
+export function validRotationFile(proposedPath: string): string | undefined {
+  if (isFile(proposedPath) && path.extname(proposedPath) === '.rot') {
+    return proposedPath;
+  }
+
+  if (isDirectory(proposedPath)) {
+    const allFilesInDir = readdirSync(proposedPath);
+    for (let i = 0; i < allFilesInDir.length; i++) {
+      const pathName = allFilesInDir[i];
+      if (path.extname(pathName) === '.rot') {
+        return path.join(proposedPath, pathName);
+      }
+    }
+  }
+
+  return;
+}


### PR DESCRIPTION
Add ability to convert directories as well as single files.

This change allows converting an unlimited number of files into a single svg, each file being organized in a `<g>` tag.

The convert command will now require a destination. Needs better error handling when there is no valid rotation file.

- [x] update interface to accept multiple file paths
- [x] extract validation into separate module
- [x] process files and directories in sequence based on the order in the command
- [x] identify the rotation file 
- [x] create svg nodes for each file in valid files
- [x] write all svg nodes to a single string
- [x] destination handling
- [x] write svg to destination
- [x] update README