### PR TITLE
fix: render SVG at 10% larger scale

### DIFF
--- a/src/modules/createSvg/createSvg.ts
+++ b/src/modules/createSvg/createSvg.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import errorProcessing from '@utilities/errorProcessing';
 
-const svgHeader = `<svg width="360" height="180" xmlns="http://www.w3.org/2000/svg">`;
+const svgHeader = `<svg width="3600" height="1800" xmlns="http://www.w3.org/2000/svg">`;
 const svgFooter = '</svg>';
 
 async function createSvg(

--- a/src/modules/createSvg/parsePoints.ts
+++ b/src/modules/createSvg/parsePoints.ts
@@ -143,7 +143,7 @@ function createPoints(currentPointsArray: ProcessedPoint[], color: string) {
   return currentPointsArray
     .map(
       (point: ProcessedPoint) =>
-        `<circle cx="${point.long}" cy="${point.lat}" r="5" style="fill:${color}" />`,
+        `<circle cx="${point.long * 10}" cy="${point.lat * 10}" r="5" style="fill:${color}" />`,
     )
     .join('');
 }
@@ -154,7 +154,7 @@ function createLine(
   metaData = '',
 ) {
   return `<polyline points="${currentPointsArray
-    .map((point: ProcessedPoint) => `${point.long} ${point.lat}`)
+    .map((point: ProcessedPoint) => `${point.long * 10} ${point.lat * 10}`)
     .join(
       ' ',
     )}" fill="none" ${metaData ? `id="${metaData}"` : ''} style="stroke:${color}; stroke-width:2" />`;
@@ -166,7 +166,7 @@ function createShape(
   metaData = '',
 ) {
   return `<polygon points="${currentPointsArray
-    .map((point: ProcessedPoint) => `${point.long} ${point.lat}`)
+    .map((point: ProcessedPoint) => `${point.long * 10} ${point.lat * 10}`)
     .join(
       ' ',
     )}" ${metaData ? `id="${metaData}"` : ''} style="fill:${color}" />`;

--- a/src/modules/featureAndRotation/featureAndRotationFactory.ts
+++ b/src/modules/featureAndRotation/featureAndRotationFactory.ts
@@ -1,9 +1,5 @@
 import parsePoints from '@modules/createSvg/parsePoints';
-import {
-  RotationDict,
-  RotationNode,
-  RotationRecord,
-} from '@projectTypes/rotationTypes';
+import { RotationNode, RotationRecord } from '@projectTypes/rotationTypes';
 import { FeatureCollection } from '@projectTypes/timeTypes';
 import { eulerToQuaternion } from '@modules/applyRotation/transformCoordinates';
 import Quaternion from 'quaternion';


### PR DESCRIPTION
Render SVG at 10% larger scale to avoid pixelation when imported into Illustrator.