### PR TITLE
add fallback for border color

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,13 @@ As of this version (0.0.1 super alpha)
 
 -----------
 I don't have a PC, so if anyone is willing to test this on a PC, I would appreciate the collaboration.
+
+
+------------
+
+## research
+
+https://alexewerlof.medium.com/node-shebang-e1d4b02f731d
+https://tsmx.net/commander-options/
+
+https://gist.github.com/dominikwilkowski/cba6c8c6b1ded8d3e3cc6bf0b7ddc432

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,14 @@
         "quaternion": "^1.5.1",
         "tsc-alias": "^1.8.10"
       },
+      "bin": {
+        "gpsvg": "dist/index.js"
+      },
       "devDependencies": {
         "@biomejs/biome": "1.8.3",
         "@eslint/js": "^8.0.0",
         "@types/node": "^20.12.12",
+        "cli-table3": "^0.6.5",
         "eslint": "^8.0.0",
         "globals": "^15.3.0",
         "prettier": "^3.2.5",
@@ -185,6 +189,16 @@
       ],
       "engines": {
         "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1633,6 +1647,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
       }
     },
     "node_modules/cli-width": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@biomejs/biome": "1.8.3",
     "@eslint/js": "^8.0.0",
     "@types/node": "^20.12.12",
+    "cli-table3": "^0.6.5",
     "eslint": "^8.0.0",
     "globals": "^15.3.0",
     "prettier": "^3.2.5",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "bin": {
-    "gpsvg": "./dist/index.js"
+    "gpsvg": "./dist/gpsvg.js"
   },
   "name": "gpml-to-svg",
   "version": "0.0.1",
   "description": "convert gpml to svg from gplates",
-  "main": "dist/index.js",
+  "main": "dist/gpsvg.js",
   "scripts": {
     "build": "tsc && tsc-alias",
     "lint": "eslint --config ./eslint.config.mjs",

--- a/src/commands/colorGradient.ts
+++ b/src/commands/colorGradient.ts
@@ -1,35 +1,38 @@
-import { stderr } from "node:process";
-import { convertRampedFileToGroup } from "@modules/colorGradient/convertRampedFileToGroup";
-import createSvg from "@modules/createSvg/createSvg";
-import { validColorRamp } from "@modules/validFiles/validColorRamp";
-import { colorValidation } from "@utilities/colorProcessing";
-import ansis from "ansis";
-import type { OptionValues } from "commander";
-import { validateRequiredFileProcessingOptions } from "middleware/validateRequiredFileProcessingOptions";
+import { stderr } from 'node:process';
+import { convertRampedFileToGroup } from '@modules/colorGradient/convertRampedFileToGroup';
+import createSvg from '@modules/createSvg/createSvg';
+import { validColorRamp } from '@modules/validFiles/validColorRamp';
+import { colorValidation } from '@utilities/colorProcessing';
+import ansis from 'ansis';
+import type { OptionValues } from 'commander';
+import { validateRequiredFileProcessingOptions } from 'middleware/validateRequiredFileProcessingOptions';
 
 export async function colorGradient(options: OptionValues) {
-	const { destination, files, rotationTimes, userFileName } =
-		await validateRequiredFileProcessingOptions(options);
+  const { destination, files, rotationTimes, userFileName } =
+    await validateRequiredFileProcessingOptions(options);
 
-	const borderColor = colorValidation(options.borderColor);
-	const timeInt = Number.parseInt(options.time);
+  const borderColor = options.borderColor
+    ? colorValidation(options.borderColor)
+    : '';
 
-	const ramp = await validColorRamp(options.colorRamp);
-	if (!ramp) {
-		stderr.write(ansis.red("No valid cpt file found. Exiting."));
-		process.exit(2);
-	}
+  const timeInt = Number.parseInt(options.time);
 
-	const finalElements = await convertRampedFileToGroup(
-		files[0],
-		rotationTimes,
-		ramp,
-		timeInt,
-	);
+  const ramp = await validColorRamp(options.colorRamp);
+  if (!ramp) {
+    stderr.write(ansis.red('No valid cpt file found. Exiting.'));
+    process.exit(2);
+  }
 
-	if (finalElements === undefined) {
-		process.exit(1);
-	}
+  const finalElements = await convertRampedFileToGroup(
+    files[0],
+    rotationTimes,
+    ramp,
+    timeInt,
+  );
 
-	createSvg(finalElements, destination, userFileName, borderColor);
+  if (finalElements === undefined) {
+    process.exit(1);
+  }
+
+  createSvg(finalElements, destination, userFileName, borderColor);
 }

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -17,7 +17,6 @@ const isFulfilled = <T>(
 ): input is PromiseFulfilledResult<T> => input.status === 'fulfilled';
 
 export async function convert(filepaths: string[], options: OptionValues) {
-  console.log({ options });
   const { destination, files, rotationTimes, userFileName } =
     await validateRequiredFileProcessingOptions(options, filepaths);
 

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -1,59 +1,64 @@
-import createSvg from "@modules/createSvg/createSvg";
+import createSvg from '@modules/createSvg/createSvg';
 import colorProcessing, {
-	colorValidation,
-	rgbToHex,
-} from "@utilities/colorProcessing";
-import type { OptionValues } from "commander";
-import { convertFileToGroup } from "../modules/convert/convertFileToGroup";
+  colorValidation,
+  rgbToHex,
+} from '@utilities/colorProcessing';
+import type { OptionValues } from 'commander';
+import { convertFileToGroup } from '../modules/convert/convertFileToGroup';
 
 import {
-	type RgbColorArrayType,
-	createColorArray,
-} from "@modules/colorMap/createColorArray";
-import { validateRequiredFileProcessingOptions } from "middleware/validateRequiredFileProcessingOptions";
+  type RgbColorArrayType,
+  createColorArray,
+} from '@modules/colorMap/createColorArray';
+import { validateRequiredFileProcessingOptions } from 'middleware/validateRequiredFileProcessingOptions';
 
 const isFulfilled = <T>(
-	input: PromiseSettledResult<T>,
-): input is PromiseFulfilledResult<T> => input.status === "fulfilled";
+  input: PromiseSettledResult<T>,
+): input is PromiseFulfilledResult<T> => input.status === 'fulfilled';
 
 export async function convert(filepaths: string[], options: OptionValues) {
-	const { destination, files, rotationTimes, userFileName } =
-		await validateRequiredFileProcessingOptions(options, filepaths);
+  console.log({ options });
+  const { destination, files, rotationTimes, userFileName } =
+    await validateRequiredFileProcessingOptions(options, filepaths);
 
-	const color = colorProcessing(options.color.toLowerCase());
-	const borderColor = colorValidation(options.borderColor);
-	const { multiColor } = options;
+  const color = colorProcessing(options.color.toLowerCase());
 
-	const timeInt = Number.parseInt(options.time);
+  const borderColor = options.borderColor
+    ? colorValidation(options.borderColor)
+    : '';
 
-	const colorMap: RgbColorArrayType[] = createColorArray(
-		color,
-		files.length,
-		multiColor,
-	);
+  const { multiColor } = options;
 
-	const processedFiles = await Promise.allSettled(
-		files.map(async (filePath, index) => {
-			// get rgb color
-			const rgbColor = colorMap[Math.min(index, colorMap.length - 1)] as [
-				number,
-				number,
-				number,
-			];
-			// convert rgb to hex
-			const hexColor = rgbToHex(rgbColor);
-			return convertFileToGroup(filePath, rotationTimes, hexColor, timeInt);
-		}),
-	);
+  const timeInt = Number.parseInt(options.time);
 
-	const finalElements: string = processedFiles
-		.filter(isFulfilled)
-		.map((record) => record.value)
-		.filter(
-			(record): record is Exclude<typeof record, undefined> =>
-				record !== undefined,
-		)
-		.join("\n");
+  const colorMap: RgbColorArrayType[] = createColorArray(
+    color,
+    files.length,
+    multiColor,
+  );
 
-	createSvg(finalElements, destination, userFileName, borderColor);
+  const processedFiles = await Promise.allSettled(
+    files.map(async (filePath, index) => {
+      // get rgb color
+      const rgbColor = colorMap[Math.min(index, colorMap.length - 1)] as [
+        number,
+        number,
+        number,
+      ];
+      // convert rgb to hex
+      const hexColor = rgbToHex(rgbColor);
+      return convertFileToGroup(filePath, rotationTimes, hexColor, timeInt);
+    }),
+  );
+
+  const finalElements: string = processedFiles
+    .filter(isFulfilled)
+    .map((record) => record.value)
+    .filter(
+      (record): record is Exclude<typeof record, undefined> =>
+        record !== undefined,
+    )
+    .join('\n');
+
+  createSvg(finalElements, destination, userFileName, borderColor);
 }

--- a/src/gpsvg.ts
+++ b/src/gpsvg.ts
@@ -2,7 +2,7 @@
 
 import { colorGradient } from '@commands/colorGradient';
 import { convert } from '@commands/convert';
-import { Command } from 'commander';
+import { Argument, Command, Help, Option } from 'commander';
 import {
   BORDER_COLOR_DECLARATION,
   BORDER_COLOR_DESCRIPTION,
@@ -22,15 +22,20 @@ import {
 } from 'constants/COMMANDER_CONSTANTS';
 
 import * as dotenv from 'dotenv';
+import { gpsvgHelp } from 'gpsvgHelp';
 dotenv.config({ path: `${__dirname}/../.env` });
 
 const program = new Command();
 
-program.enablePositionalOptions().option('-p, --progress');
-
 program
-  .version('0.0.1')
-  .description('A CLI for converting GPLates GPML files to SVGs.');
+  .configureHelp({
+    helpWidth: 40,
+    sortOptions: true,
+    subcommandTerm: (cmd) => cmd.name(),
+  })
+  .addHelpText('before', gpsvgHelp);
+
+program.version('0.0.2');
 
 program
   .command('convert')

--- a/src/gpsvgHelp.ts
+++ b/src/gpsvgHelp.ts
@@ -1,0 +1,11 @@
+import ansis from 'ansis';
+
+export function gpsvgHelp(): string {
+  return `
+    ${ansis.bgBlack.blueBright(' GPSVG cli for converting GPlates files to vectors ')}
+
+    Use this cli to convert multiple files into a single SVG, or a single 
+    file into an SVG with a color gradient that colors features according
+    to age as described by a color ramp.
+  `;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ program
 
 program
   .command('convert')
+  .description('Convert one or more files to an SVG.')
   .requiredOption(TIME_DECLARATION, TIME_DESCRIPTION)
   .requiredOption(DESTINATION_DECLARATION, DESTINATION_DESCRIPTION)
   .option(FILL_COLOR_DECLARATION, FILL_COLOR_DESCRIPTION, FILL_COLOR_DEFAULT)
@@ -48,6 +49,9 @@ program
 
 program
   .command('color-gradient')
+  .description(
+    'Convert a single file to an SVG with a color ramp to indicate age.',
+  )
   .requiredOption(TIME_DECLARATION, TIME_DESCRIPTION)
   .requiredOption(DESTINATION_DECLARATION, DESTINATION_DESCRIPTION)
   .requiredOption(
@@ -63,7 +67,3 @@ program
   });
 
 program.parse(process.argv);
-
-if (!process.argv.slice(2).length) {
-  program.outputHelp();
-}

--- a/src/modules/applyRotation/transformCoordinates.test.ts
+++ b/src/modules/applyRotation/transformCoordinates.test.ts
@@ -1,320 +1,320 @@
-import type Quaternion from "quaternion";
-import { describe, expect, it, test } from "vitest";
+import type Quaternion from 'quaternion';
+import { describe, expect, it, test } from 'vitest';
 
 import {
-	cartesianToLatLong,
-	eulerToQuaternion,
-	latLonToCartesian,
-	quaternionToEulerPole,
-	transformPointBetweenPoles,
-} from "./transformCoordinates";
+  cartesianToLatLong,
+  eulerToQuaternion,
+  latLonToCartesian,
+  quaternionToEulerPole,
+  transformPointBetweenPoles,
+} from './transformCoordinates';
 
 const latLonToCartesianCases = [
-	{
-		name: "where 45, 45 generates [0.5, 0.5, 0.7071067811865475]",
-		lat: 45,
-		lon: 45,
-		expected: [0.5, 0.5, 0.7071067811865475],
-	},
-	{
-		name: "where 0, 90 generates [0, 1, 0]",
-		lat: 0,
-		lon: 90,
-		expected: [0, 1, 0],
-	},
-	{
-		name: "where 0, -90 generates [0, -1, 0]",
-		lat: 0,
-		lon: -90,
-		expected: [0, -1, 0],
-	},
-	{
-		name: "where 0, 180 generates [-1, 0, 0]",
-		lat: 0,
-		lon: 180,
-		expected: [-1, 0, 0],
-	},
-	{
-		name: "where 0, -180 generates [-1, 0, 0]",
-		lat: 0,
-		lon: -180,
-		expected: [-1, 0, 0],
-	},
-	{
-		name: "where 35, 61 generates [0.3972, 0.71644, 0.5736]",
-		lat: 35,
-		lon: 61,
-		expected: [0.3972, 0.71644, 0.5736],
-	},
+  {
+    name: 'where 45, 45 generates [0.5, 0.5, 0.7071067811865475]',
+    lat: 45,
+    lon: 45,
+    expected: [0.5, 0.5, 0.7071067811865475],
+  },
+  {
+    name: 'where 0, 90 generates [0, 1, 0]',
+    lat: 0,
+    lon: 90,
+    expected: [0, 1, 0],
+  },
+  {
+    name: 'where 0, -90 generates [0, -1, 0]',
+    lat: 0,
+    lon: -90,
+    expected: [0, -1, 0],
+  },
+  {
+    name: 'where 0, 180 generates [-1, 0, 0]',
+    lat: 0,
+    lon: 180,
+    expected: [-1, 0, 0],
+  },
+  {
+    name: 'where 0, -180 generates [-1, 0, 0]',
+    lat: 0,
+    lon: -180,
+    expected: [-1, 0, 0],
+  },
+  {
+    name: 'where 35, 61 generates [0.3972, 0.71644, 0.5736]',
+    lat: 35,
+    lon: 61,
+    expected: [0.3972, 0.71644, 0.5736],
+  },
 ];
 
-describe("latLonToCartesian", () => {
-	test.each(latLonToCartesianCases)("$name", ({ lat, lon, expected }) => {
-		const result = latLonToCartesian(lat, lon);
-		expect(result[0]).toBeCloseTo(expected[0], 2);
-		expect(result[1]).toBeCloseTo(expected[1], 2);
-		expect(result[2]).toBeCloseTo(expected[2], 2);
-	});
+describe('latLonToCartesian', () => {
+  test.each(latLonToCartesianCases)('$name', ({ lat, lon, expected }) => {
+    const result = latLonToCartesian(lat, lon);
+    expect(result[0]).toBeCloseTo(expected[0], 2);
+    expect(result[1]).toBeCloseTo(expected[1], 2);
+    expect(result[2]).toBeCloseTo(expected[2], 2);
+  });
 });
 
 const LclArray = [
-	{ name: "where 0, 0 generates 0, 0", x: 1, y: 0, z: 0, expected: [0, 0] },
-	{
-		name: "where 0.5, 0.5, 0.70711 generates 45, 45",
-		x: 0.5,
-		y: 0.5,
-		z: Math.SQRT1_2,
-		expected: [45, 45],
-	},
-	{
-		name: "where 0, 1, 0 generates 0, 90",
-		x: 0,
-		y: 1,
-		z: 0,
-		expected: [0, 90],
-	},
-	{
-		name: "where 0, -1, 0 generates 0, -90",
-		x: 0,
-		y: -1,
-		z: 0,
-		expected: [0, -90],
-	},
-	{
-		name: "where -1, 0, 0 generates 0, 180",
-		x: -1,
-		y: 0,
-		z: 0,
-		expected: [0, 180],
-	},
-	{
-		name: "where 0, -1, 0 generates 0, -90",
-		x: 0,
-		y: -1,
-		z: 0,
-		expected: [0, -90],
-	},
-	{
-		name: "where 0.3972, 0.71644, 0.5736 generates 35, 61",
-		x: 0.3972,
-		y: 0.71644,
-		z: 0.5736,
-		expected: [35, 61],
-	},
+  { name: 'where 0, 0 generates 0, 0', x: 1, y: 0, z: 0, expected: [0, 0] },
+  {
+    name: 'where 0.5, 0.5, 0.70711 generates 45, 45',
+    x: 0.5,
+    y: 0.5,
+    z: Math.SQRT1_2,
+    expected: [45, 45],
+  },
+  {
+    name: 'where 0, 1, 0 generates 0, 90',
+    x: 0,
+    y: 1,
+    z: 0,
+    expected: [0, 90],
+  },
+  {
+    name: 'where 0, -1, 0 generates 0, -90',
+    x: 0,
+    y: -1,
+    z: 0,
+    expected: [0, -90],
+  },
+  {
+    name: 'where -1, 0, 0 generates 0, 180',
+    x: -1,
+    y: 0,
+    z: 0,
+    expected: [0, 180],
+  },
+  {
+    name: 'where 0, -1, 0 generates 0, -90',
+    x: 0,
+    y: -1,
+    z: 0,
+    expected: [0, -90],
+  },
+  {
+    name: 'where 0.3972, 0.71644, 0.5736 generates 35, 61',
+    x: 0.3972,
+    y: 0.71644,
+    z: 0.5736,
+    expected: [35, 61],
+  },
 ];
 
-describe("cartesianToLatLong", () => {
-	test.each(LclArray)("$name", ({ x, y, z, expected }) => {
-		const [lat, lon] = cartesianToLatLong(x, y, z);
-		const [resultLat, resultLon] = expected;
-		expect(lat).toBeCloseTo(resultLat, 2);
-		expect(lon).toBeCloseTo(resultLon, 2);
-	});
+describe('cartesianToLatLong', () => {
+  test.each(LclArray)('$name', ({ x, y, z, expected }) => {
+    const [lat, lon] = cartesianToLatLong(x, y, z);
+    const [resultLat, resultLon] = expected;
+    expect(lat).toBeCloseTo(resultLat, 2);
+    expect(lon).toBeCloseTo(resultLon, 2);
+  });
 });
 
 const transformPointBetweenPolesCases = [
-	{
-		name: "using gplates real case",
-		point: [1, 0, 0],
-		initialPole: {
-			lat_of_euler_pole: 90,
-			lon_of_euler_pole: 0,
-			rotation_angle: 0,
-		},
-		newPole: {
-			lat_of_euler_pole: -34.4489,
-			lon_of_euler_pole: 65.8376,
-			rotation_angle: -51.2807,
-		},
-		expected: [0.6681732808036102, 0.5364546671230196, 0.5155199869472283],
-	},
-	{
-		name: "where point [1, 0, 0] is transformed from initial pole to new pole",
-		point: [1, 0, 0],
-		initialPole: {
-			lat_of_euler_pole: 90,
-			lon_of_euler_pole: 0,
-			rotation_angle: 0,
-		},
-		newPole: {
-			lat_of_euler_pole: 90,
-			lon_of_euler_pole: 0,
-			rotation_angle: 30,
-		},
-		expected: [0.8660254037844387, 0.5, 0],
-	},
-	{
-		name: "in the series, the same point goes to a third pole",
-		point: [0.8660254037844387, 0.5, 0],
-		initialPole: {
-			lat_of_euler_pole: 90,
-			lon_of_euler_pole: 0,
-			rotation_angle: 30,
-		},
-		newPole: {
-			lat_of_euler_pole: 20,
-			lon_of_euler_pole: 45,
-			rotation_angle: 30,
-		},
-		expected: [0.9251766765758391, 0.23016134445423478, -0.30178448044772743],
-	},
-	{
-		name: "using no rotation",
-		point: [1, 0, 0],
-		initialPole: {
-			lat_of_euler_pole: 90,
-			lon_of_euler_pole: 0,
-			rotation_angle: 0,
-		},
-		newPole: {
-			lat_of_euler_pole: 90,
-			lon_of_euler_pole: 0,
-			rotation_angle: 0,
-		},
-		expected: [1, 0, 0],
-	},
-	{
-		name: "using test planet and motion",
-		point: [1, 0, 0],
-		initialPole: {
-			lat_of_euler_pole: 90,
-			lon_of_euler_pole: 0,
-			rotation_angle: 0,
-		},
-		newPole: {
-			lat_of_euler_pole: 90,
-			lon_of_euler_pole: 0,
-			rotation_angle: -30,
-		},
-		expected: [0.8660254037844387, -0.5, 0],
-	},
+  {
+    name: 'using gplates real case',
+    point: [1, 0, 0],
+    initialPole: {
+      lat_of_euler_pole: 90,
+      lon_of_euler_pole: 0,
+      rotation_angle: 0,
+    },
+    newPole: {
+      lat_of_euler_pole: -34.4489,
+      lon_of_euler_pole: 65.8376,
+      rotation_angle: -51.2807,
+    },
+    expected: [0.6681732808036102, 0.5364546671230196, 0.5155199869472283],
+  },
+  {
+    name: 'where point [1, 0, 0] is transformed from initial pole to new pole',
+    point: [1, 0, 0],
+    initialPole: {
+      lat_of_euler_pole: 90,
+      lon_of_euler_pole: 0,
+      rotation_angle: 0,
+    },
+    newPole: {
+      lat_of_euler_pole: 90,
+      lon_of_euler_pole: 0,
+      rotation_angle: 30,
+    },
+    expected: [0.8660254037844387, 0.5, 0],
+  },
+  {
+    name: 'in the series, the same point goes to a third pole',
+    point: [0.8660254037844387, 0.5, 0],
+    initialPole: {
+      lat_of_euler_pole: 90,
+      lon_of_euler_pole: 0,
+      rotation_angle: 30,
+    },
+    newPole: {
+      lat_of_euler_pole: 20,
+      lon_of_euler_pole: 45,
+      rotation_angle: 30,
+    },
+    expected: [0.9251766765758391, 0.23016134445423478, -0.30178448044772743],
+  },
+  {
+    name: 'using no rotation',
+    point: [1, 0, 0],
+    initialPole: {
+      lat_of_euler_pole: 90,
+      lon_of_euler_pole: 0,
+      rotation_angle: 0,
+    },
+    newPole: {
+      lat_of_euler_pole: 90,
+      lon_of_euler_pole: 0,
+      rotation_angle: 0,
+    },
+    expected: [1, 0, 0],
+  },
+  {
+    name: 'using test planet and motion',
+    point: [1, 0, 0],
+    initialPole: {
+      lat_of_euler_pole: 90,
+      lon_of_euler_pole: 0,
+      rotation_angle: 0,
+    },
+    newPole: {
+      lat_of_euler_pole: 90,
+      lon_of_euler_pole: 0,
+      rotation_angle: -30,
+    },
+    expected: [0.8660254037844387, -0.5, 0],
+  },
 ];
 
-describe("transformPointBetweenPoles", () => {
-	test.each(transformPointBetweenPolesCases)(
-		"$name",
-		({ point, initialPole, newPole, expected }) => {
-			const result = transformPointBetweenPoles(
-				point as [number, number, number],
-				initialPole,
-				newPole,
-			);
+describe('transformPointBetweenPoles', () => {
+  test.each(transformPointBetweenPolesCases)(
+    '$name',
+    ({ point, initialPole, newPole, expected }) => {
+      const result = transformPointBetweenPoles(
+        point as [number, number, number],
+        initialPole,
+        newPole,
+      );
 
-			expect(result[0]).toBeCloseTo(expected[0], 3);
-			expect(result[1]).toBeCloseTo(expected[1], 3);
-			expect(result[2]).toBeCloseTo(expected[2], 3);
-		},
-	);
+      expect(result[0]).toBeCloseTo(expected[0], 3);
+      expect(result[1]).toBeCloseTo(expected[1], 3);
+      expect(result[2]).toBeCloseTo(expected[2], 3);
+    },
+  );
 });
 
 const quaternionToEulerPoleCases = [
-	{
-		name: "where quaternion [0, 0, 0, 1] generates euler pole [0, 0, 90]",
-		quaternion: { w: 0, x: 0, y: 0, z: 1 },
-		expected: {
-			lat_of_euler_pole: 90,
-			lon_of_euler_pole: 0,
-			rotation_angle: 180,
-		},
-	},
-	{
-		name: "where quaternion [0.5, 0.5, 0.5, 0.5] generates euler pole [0, 0, 45]",
-		quaternion: { w: 0.5, x: 0.5, y: 0.5, z: 0.5 },
-		expected: {
-			lat_of_euler_pole: 35.264,
-			lon_of_euler_pole: 45,
-			rotation_angle: 120,
-		},
-	},
-	{
-		name: "where quaternion [0.866, 0, 0, 0.5] generates euler pole [0, 0, 30]",
-		quaternion: { w: 0.866, x: 0, y: 0, z: 0.5 },
-		expected: {
-			lat_of_euler_pole: 90,
-			lon_of_euler_pole: 0,
-			rotation_angle: 60.00582186237605,
-		},
-	},
-	{
-		name: "where quaternion [0.707, 0, 0, 0.707] generates euler pole [90, 0 90]",
-		quaternion: { w: Math.SQRT1_2, x: 0, y: 0, z: Math.SQRT1_2 },
-		expected: {
-			lat_of_euler_pole: 90,
-			lon_of_euler_pole: 0,
-			rotation_angle: 90.0173,
-		},
-	},
-	{
-		name: "where quaternion [0, 0.707, 0, 0.707] generates euler pole [0, 90, 45]",
-		quaternion: { w: 0, x: Math.SQRT1_2, y: 0, z: Math.SQRT1_2 },
-		expected: {
-			lat_of_euler_pole: 45,
-			lon_of_euler_pole: 0,
-			rotation_angle: 180,
-		},
-	},
+  {
+    name: 'where quaternion [0, 0, 0, 1] generates euler pole [0, 0, 90]',
+    quaternion: { w: 0, x: 0, y: 0, z: 1 },
+    expected: {
+      lat_of_euler_pole: 90,
+      lon_of_euler_pole: 0,
+      rotation_angle: 180,
+    },
+  },
+  {
+    name: 'where quaternion [0.5, 0.5, 0.5, 0.5] generates euler pole [0, 0, 45]',
+    quaternion: { w: 0.5, x: 0.5, y: 0.5, z: 0.5 },
+    expected: {
+      lat_of_euler_pole: 35.264,
+      lon_of_euler_pole: 45,
+      rotation_angle: 120,
+    },
+  },
+  {
+    name: 'where quaternion [0.866, 0, 0, 0.5] generates euler pole [0, 0, 30]',
+    quaternion: { w: 0.866, x: 0, y: 0, z: 0.5 },
+    expected: {
+      lat_of_euler_pole: 90,
+      lon_of_euler_pole: 0,
+      rotation_angle: 60.00582186237605,
+    },
+  },
+  {
+    name: 'where quaternion [0.707, 0, 0, 0.707] generates euler pole [90, 0 90]',
+    quaternion: { w: Math.SQRT1_2, x: 0, y: 0, z: Math.SQRT1_2 },
+    expected: {
+      lat_of_euler_pole: 90,
+      lon_of_euler_pole: 0,
+      rotation_angle: 90,
+    },
+  },
+  {
+    name: 'where quaternion [0, 0.707, 0, 0.707] generates euler pole [0, 90, 45]',
+    quaternion: { w: 0, x: Math.SQRT1_2, y: 0, z: Math.SQRT1_2 },
+    expected: {
+      lat_of_euler_pole: 45,
+      lon_of_euler_pole: 0,
+      rotation_angle: 180,
+    },
+  },
 ];
 
-describe("quaternionToEulerPole", () => {
-	test.each(quaternionToEulerPoleCases)("$name", ({ quaternion, expected }) => {
-		const result = quaternionToEulerPole(quaternion as Quaternion);
+describe('quaternionToEulerPole', () => {
+  test.each(quaternionToEulerPoleCases)('$name', ({ quaternion, expected }) => {
+    const result = quaternionToEulerPole(quaternion as Quaternion);
 
-		expect(result.lat_of_euler_pole).toBeCloseTo(expected.lat_of_euler_pole, 3);
-		expect(result.lon_of_euler_pole).toBeCloseTo(expected.lon_of_euler_pole, 3);
-		expect(result.rotation_angle).toBeCloseTo(expected.rotation_angle, 3);
-	});
+    expect(result.lat_of_euler_pole).toBeCloseTo(expected.lat_of_euler_pole, 3);
+    expect(result.lon_of_euler_pole).toBeCloseTo(expected.lon_of_euler_pole, 3);
+    expect(result.rotation_angle).toBeCloseTo(expected.rotation_angle, 3);
+  });
 });
 
 const eulerToQuaternionCases = [
-	{
-		name: "where euler pole [0, 0, 90] generates quaternion [0, 0, 0, 1]",
-		euler: { lat_of_euler_pole: 90, lon_of_euler_pole: 0, rotation_angle: 180 },
-		expected: { w: 0, x: 0, y: 0, z: 1 },
-	},
-	{
-		name: "where euler pole [0, 0, 45] generates quaternion [0.5, 0.5, 0.5, 0.5]",
-		euler: {
-			lat_of_euler_pole: 35.264,
-			lon_of_euler_pole: 45,
-			rotation_angle: 120,
-		},
-		expected: { w: 0.5, x: 0.5, y: 0.5, z: 0.5 },
-	},
-	{
-		name: "where euler pole [0, 0, 30] generates quaternion [0.866, 0, 0, 0.5]",
-		euler: {
-			lat_of_euler_pole: 89.23993017780637,
-			lon_of_euler_pole: 0,
-			rotation_angle: 60.00582186237605,
-		},
-		expected: { w: 0.866, x: 0.0066, y: 0, z: 0.5 },
-	},
-	{
-		name: "where euler pole [0, 0, 45] generates quaternion [0.707, 0, 0, 0.707]",
-		euler: {
-			lat_of_euler_pole: 88.5919462011935,
-			lon_of_euler_pole: 0,
-			rotation_angle: 90.017303325676,
-		},
-		expected: { w: Math.SQRT1_2, x: 0.0173, y: 0, z: Math.SQRT1_2 },
-	},
-	{
-		name: "where euler pole [0, 90, 45] generates quaternion [0, 0.707, 0, 0.707]",
-		euler: {
-			lat_of_euler_pole: 44.991348337,
-			lon_of_euler_pole: 0,
-			rotation_angle: 180,
-		},
-		expected: { w: 0, x: Math.SQRT1_2, y: 0, z: Math.SQRT1_2 },
-	},
+  {
+    name: 'where euler pole [0, 0, 90] generates quaternion [0, 0, 0, 1]',
+    euler: { lat_of_euler_pole: 90, lon_of_euler_pole: 0, rotation_angle: 180 },
+    expected: { w: 0, x: 0, y: 0, z: 1 },
+  },
+  {
+    name: 'where euler pole [0, 0, 45] generates quaternion [0.5, 0.5, 0.5, 0.5]',
+    euler: {
+      lat_of_euler_pole: 35.264,
+      lon_of_euler_pole: 45,
+      rotation_angle: 120,
+    },
+    expected: { w: 0.5, x: 0.5, y: 0.5, z: 0.5 },
+  },
+  {
+    name: 'where euler pole [0, 0, 30] generates quaternion [0.866, 0, 0, 0.5]',
+    euler: {
+      lat_of_euler_pole: 89.23993017780637,
+      lon_of_euler_pole: 0,
+      rotation_angle: 60.00582186237605,
+    },
+    expected: { w: 0.866, x: 0.0066, y: 0, z: 0.5 },
+  },
+  {
+    name: 'where euler pole [0, 0, 45] generates quaternion [0.707, 0, 0, 0.707]',
+    euler: {
+      lat_of_euler_pole: 88.5919462011935,
+      lon_of_euler_pole: 0,
+      rotation_angle: 90.017303325676,
+    },
+    expected: { w: Math.SQRT1_2, x: 0.0173, y: 0, z: Math.SQRT1_2 },
+  },
+  {
+    name: 'where euler pole [0, 90, 45] generates quaternion [0, 0.707, 0, 0.707]',
+    euler: {
+      lat_of_euler_pole: 44.991348337,
+      lon_of_euler_pole: 0,
+      rotation_angle: 180,
+    },
+    expected: { w: 0, x: Math.SQRT1_2, y: 0, z: Math.SQRT1_2 },
+  },
 ];
 
-describe("eulerToQuaternion", () => {
-	test.each(eulerToQuaternionCases)("$name", ({ name, euler, expected }) => {
-		const result = eulerToQuaternion(euler);
-		expect(result.w).toBeCloseTo(expected.w, 3);
-		expect(result.x).toBeCloseTo(expected.x, 3);
-		expect(result.y).toBeCloseTo(expected.y, 3);
-		expect(result.z).toBeCloseTo(expected.z, 3);
-	});
+describe('eulerToQuaternion', () => {
+  test.each(eulerToQuaternionCases)('$name', ({ name, euler, expected }) => {
+    const result = eulerToQuaternion(euler);
+    expect(result.w).toBeCloseTo(expected.w, 3);
+    expect(result.x).toBeCloseTo(expected.x, 3);
+    expect(result.y).toBeCloseTo(expected.y, 3);
+    expect(result.z).toBeCloseTo(expected.z, 3);
+  });
 });

--- a/src/modules/colorGradient/convertRampedFileToGroup.ts
+++ b/src/modules/colorGradient/convertRampedFileToGroup.ts
@@ -1,43 +1,42 @@
-import { filterForTime } from "@modules/findNodes/filterForTime";
-import { parseToJson } from "@modules/findNodes/parseToJson";
+import { filterForTime } from '@modules/findNodes/filterForTime';
+import { parseToJson } from '@modules/findNodes/parseToJson';
 
-import path from "node:path";
-import type { CptRampRuleArray } from "@modules/validFiles/jsonFromCpt";
-import type { RotationRecord } from "@projectTypes/rotationTypes";
-import type { FeatureCollection } from "@projectTypes/timeTypes";
-import { processedFileName } from "@utilities/processedFileName";
-import { featureColorAndRotationFactory } from "./featureColorAndRotationFactory";
+import path from 'node:path';
+import type { CptRampRuleArray } from '@modules/validFiles/jsonFromCpt';
+import type { RotationRecord } from '@projectTypes/rotationTypes';
+import type { GPlates_Feature } from '@projectTypes/timeTypes';
+import { processedFileName } from '@utilities/processedFileName';
+import { featureColorAndRotationFactory } from './featureColorAndRotationFactory';
 
 export async function convertRampedFileToGroup(
-	filepath: string,
-	rotationTimes: RotationRecord,
-	colorRamp: CptRampRuleArray,
-	time: number,
+  filepath: string,
+  rotationTimes: RotationRecord,
+  colorRamp: CptRampRuleArray,
+  time: number,
 ): Promise<string | undefined> {
-	let featureArray: FeatureCollection[] | undefined =
-		await parseToJson(filepath);
+  let featureArray: GPlates_Feature[] | undefined = await parseToJson(filepath);
 
-	if (!featureArray) {
-		throw new Error("No features found in file");
-	}
+  if (!featureArray) {
+    throw new Error('No features found in file');
+  }
 
-	// Finds all features that are valid at the given time
-	featureArray = filterForTime(featureArray, time);
-	const fileName = processedFileName(path.basename(filepath), false);
+  // Finds all features that are valid at the given time
+  featureArray = filterForTime(featureArray, time);
+  const fileName = processedFileName(path.basename(filepath), false);
 
-	const parsePointsWithRotation = featureColorAndRotationFactory(
-		colorRamp,
-		rotationTimes,
-		time,
-	);
+  const parsePointsWithRotation = featureColorAndRotationFactory(
+    colorRamp,
+    rotationTimes,
+    time,
+  );
 
-	const svgFeatures = featureArray
-		?.map((feature) => parsePointsWithRotation(feature))
-		.join("");
+  const svgFeatures = featureArray
+    ?.map((feature) => parsePointsWithRotation(feature))
+    .join('');
 
-	if (svgFeatures?.length) {
-		return `<g id="${fileName}">${svgFeatures}</g>`;
-	}
+  if (svgFeatures?.length) {
+    return `<g id="${fileName}">${svgFeatures}</g>`;
+  }
 
-	return;
+  return;
 }

--- a/src/modules/colorGradient/featureColorAndRotationFactory.ts
+++ b/src/modules/colorGradient/featureColorAndRotationFactory.ts
@@ -1,49 +1,53 @@
-import parsePoints from "@modules/createSvg/parsePoints";
-import { findFinalRotation } from "@modules/findFinalRotation/findFinalRotation";
-import type { CptRampRuleArray } from "@modules/validFiles/jsonFromCpt";
-import type { RotationNode, RotationRecord } from "@projectTypes/rotationTypes";
-import type { FeatureCollection, TimeInstant } from "@projectTypes/timeTypes";
-import { rgbToHex } from "@utilities/colorProcessing";
-import type Quaternion from "quaternion";
-import { gradedStepFactory } from "./gradedStepFactory";
+import parsePoints from '@modules/createSvg/parsePoints';
+import { findFinalRotation } from '@modules/findFinalRotation/findFinalRotation';
+import type { CptRampRuleArray } from '@modules/validFiles/jsonFromCpt';
+import type { RotationNode, RotationRecord } from '@projectTypes/rotationTypes';
+import type {
+  FeatureCollection,
+  GPlates_Feature,
+  TimeInstant,
+} from '@projectTypes/timeTypes';
+import { rgbToHex } from '@utilities/colorProcessing';
+import type Quaternion from 'quaternion';
+import { gradedStepFactory } from './gradedStepFactory';
 
 function getTimeFromTimeInstant(time: TimeInstant): number {
-	const value = time.timePosition;
-	if (typeof value === "string") {
-		return Number.parseInt(value);
-	}
+  const value = time.timePosition;
+  if (typeof value === 'string') {
+    return Number.parseInt(value);
+  }
 
-	return value as unknown as number;
+  return value as unknown as number;
 }
 
 export function featureColorAndRotationFactory(
-	colorRamp: CptRampRuleArray,
-	rotationTimes: RotationRecord,
-	targetTime: number,
+  colorRamp: CptRampRuleArray,
+  rotationTimes: RotationRecord,
+  targetTime: number,
 ) {
-	const gradedColor = gradedStepFactory(colorRamp);
+  const gradedColor = gradedStepFactory(colorRamp);
 
-	return (feature: FeatureCollection) => {
-		const plateId = feature.reconstructionPlateId?.ConstantValue?.value;
-		const age =
-			getTimeFromTimeInstant(feature.validTime.TimePeriod.begin.TimeInstant) -
-			targetTime;
+  return (feature: GPlates_Feature) => {
+    const plateId = feature.reconstructionPlateId?.ConstantValue?.value;
+    const age =
+      getTimeFromTimeInstant(feature.validTime.TimePeriod.begin.TimeInstant) -
+      targetTime;
 
-		const rotationNode: RotationNode = rotationTimes[plateId] as RotationNode;
+    const rotationNode: RotationNode = rotationTimes[plateId] as RotationNode;
 
-		const hexColor = rgbToHex(gradedColor(age));
+    const hexColor = rgbToHex(gradedColor(age));
 
-		if (plateId) {
-			try {
-				const finalRotation: Quaternion = findFinalRotation(
-					rotationNode,
-					rotationTimes,
-				);
+    if (plateId) {
+      try {
+        const finalRotation: Quaternion = findFinalRotation(
+          rotationNode,
+          rotationTimes,
+        );
 
-				return parsePoints(feature, hexColor, finalRotation);
-			} catch (e) {
-				console.log(e, feature.reconstructionPlateId);
-			}
-		}
-	};
+        return parsePoints(feature, hexColor, finalRotation);
+      } catch (e) {
+        console.log(e, feature.reconstructionPlateId);
+      }
+    }
+  };
 }

--- a/src/modules/convert/convertFileToGroup.ts
+++ b/src/modules/convert/convertFileToGroup.ts
@@ -1,38 +1,40 @@
-import { filterForTime } from "@modules/findNodes/filterForTime";
-import { parseToJson } from "@modules/findNodes/parseToJson";
+import { filterForTime } from '@modules/findNodes/filterForTime';
+import { parseToJson } from '@modules/findNodes/parseToJson';
 
-import path from "node:path";
-import { featureAndRotationFactory } from "@modules/convert/featureAndRotationFactory";
-import type { RotationRecord } from "@projectTypes/rotationTypes";
-import type { FeatureCollection } from "@projectTypes/timeTypes";
-import { processedFileName } from "@utilities/processedFileName";
+import path from 'node:path';
+import { featureAndRotationFactory } from '@modules/convert/featureAndRotationFactory';
+import type { RotationRecord } from '@projectTypes/rotationTypes';
+import type {
+  FeatureCollection,
+  GPlates_Feature,
+} from '@projectTypes/timeTypes';
+import { processedFileName } from '@utilities/processedFileName';
 
 export async function convertFileToGroup(
-	filepath: string,
-	rotationTimes: RotationRecord,
-	color: string,
-	time: number,
+  filepath: string,
+  rotationTimes: RotationRecord,
+  color: string,
+  time: number,
 ): Promise<string | undefined> {
-	let featureArray: FeatureCollection[] | undefined =
-		await parseToJson(filepath);
+  let featureArray: GPlates_Feature[] | undefined = await parseToJson(filepath);
 
-	if (!featureArray) {
-		throw new Error("No features found in file");
-	}
+  if (!featureArray) {
+    throw new Error('No features found in file');
+  }
 
-	// Finds all features that are valid at the given time
-	featureArray = filterForTime(featureArray, time);
-	const fileName = processedFileName(path.basename(filepath), false);
+  // Finds all features that are valid at the given time
+  featureArray = filterForTime(featureArray, time);
+  const fileName = processedFileName(path.basename(filepath), false);
 
-	const parsePointsWithRotation = featureAndRotationFactory(rotationTimes);
+  const parsePointsWithRotation = featureAndRotationFactory(rotationTimes);
 
-	const svgFeatures = featureArray
-		?.map((feature) => parsePointsWithRotation(feature, color))
-		.join("");
+  const svgFeatures = featureArray
+    ?.map((feature) => parsePointsWithRotation(feature, color))
+    .join('');
 
-	if (svgFeatures?.length) {
-		return `<g id="${fileName}">${svgFeatures}</g>`;
-	}
+  if (svgFeatures?.length) {
+    return `<g id="${fileName}">${svgFeatures}</g>`;
+  }
 
-	return;
+  return;
 }

--- a/src/modules/convert/featureAndRotationFactory.ts
+++ b/src/modules/convert/featureAndRotationFactory.ts
@@ -1,25 +1,28 @@
-import parsePoints from "@modules/createSvg/parsePoints";
-import { findFinalRotation } from "@modules/findFinalRotation/findFinalRotation";
-import type { RotationNode, RotationRecord } from "@projectTypes/rotationTypes";
-import type { FeatureCollection } from "@projectTypes/timeTypes";
-import type Quaternion from "quaternion";
+import parsePoints from '@modules/createSvg/parsePoints';
+import { findFinalRotation } from '@modules/findFinalRotation/findFinalRotation';
+import type { RotationNode, RotationRecord } from '@projectTypes/rotationTypes';
+import type {
+  FeatureCollection,
+  GPlates_Feature,
+} from '@projectTypes/timeTypes';
+import type Quaternion from 'quaternion';
 
 export function featureAndRotationFactory(rotationTimes: RotationRecord) {
-	return (feature: FeatureCollection, color: string) => {
-		const plateId = feature.reconstructionPlateId?.ConstantValue?.value;
-		const rotationNode: RotationNode = rotationTimes[plateId] as RotationNode;
+  return (feature: GPlates_Feature, color: string) => {
+    const plateId = feature.reconstructionPlateId?.ConstantValue?.value;
+    const rotationNode: RotationNode = rotationTimes[plateId] as RotationNode;
 
-		if (plateId) {
-			try {
-				const finalRotation: Quaternion = findFinalRotation(
-					rotationNode,
-					rotationTimes,
-				);
+    if (plateId) {
+      try {
+        const finalRotation: Quaternion = findFinalRotation(
+          rotationNode,
+          rotationTimes,
+        );
 
-				return parsePoints(feature, color, finalRotation);
-			} catch (e) {
-				console.log(e, feature.reconstructionPlateId);
-			}
-		}
-	};
+        return parsePoints(feature, color, finalRotation);
+      } catch (e) {
+        console.log(e, feature.reconstructionPlateId);
+      }
+    }
+  };
 }

--- a/src/modules/createSvg/createSvg.ts
+++ b/src/modules/createSvg/createSvg.ts
@@ -1,43 +1,43 @@
-import { promises as fs } from "node:fs";
-import { stderr } from "node:process";
-import errorProcessing from "@utilities/errorProcessing";
-import ansis from "ansis";
+import { promises as fs } from 'node:fs';
+import { stderr } from 'node:process';
+import errorProcessing from '@utilities/errorProcessing';
+import ansis from 'ansis';
 
 const svgWidth = 3600;
 const svgHeight = 1800;
 
 const svgHeader = `<svg width="${svgWidth}" height="${svgHeight}" xmlns="http://www.w3.org/2000/svg">`;
 
-const svgFooter = "</svg>";
+const svgFooter = '</svg>';
 
 async function createSvg(
-	featureString: string,
-	destPath: string,
-	fileName = "test.svg",
-	borderColor = "",
+  featureString: string,
+  destPath: string,
+  fileName = 'test.svg',
+  borderColor = '',
 ) {
-	const svgBorder = `<rect width="${svgWidth}" height="${svgHeight}" style="fill:none;${borderColor.length > 0 ? `stroke-width:3;stroke:${borderColor};` : ""}" />`;
-	const content = `${svgHeader}${svgBorder}${featureString}${svgFooter}`;
+  const svgBorder = `<rect width="${svgWidth}" height="${svgHeight}" style="fill:none;${borderColor.length > 0 ? `stroke-width:3;stroke:${borderColor};` : ''}" />`;
+  const content = `${svgHeader}${svgBorder}${featureString}${svgFooter}`;
 
-	let finalFileName = fileName;
+  let finalFileName = fileName;
 
-	if (fileName.slice(-4) !== ".svg") {
-		finalFileName += ".svg";
-	}
+  if (fileName.slice(-4) !== '.svg') {
+    finalFileName += '.svg';
+  }
 
-	await fs
-		.mkdir(destPath, { recursive: true })
-		.then(() =>
-			stderr.write(
-				ansis.green(`\nFile "${fileName}" written to '${destPath}'.\n`),
-			),
-		) //console.log()
-		.catch((err) => console.error(`Error creating directory: ${err.message}`));
-	try {
-		fs.writeFile(`${destPath}/${fileName}`, content);
-	} catch (err: unknown) {
-		errorProcessing(err);
-	}
+  await fs
+    .mkdir(destPath, { recursive: true })
+    .then(() =>
+      stderr.write(
+        ansis.green(`\nFile "${fileName}" written to '${destPath}'.\n`),
+      ),
+    ) //console.log()
+    .catch((err) => console.error(`Error creating directory: ${err.message}`));
+  try {
+    fs.writeFile(`${destPath}/${fileName}`, content);
+  } catch (err: unknown) {
+    errorProcessing(err);
+  }
 }
 
 export default createSvg;

--- a/src/modules/createSvg/createSvg.ts
+++ b/src/modules/createSvg/createSvg.ts
@@ -31,7 +31,7 @@ async function createSvg(
       stderr.write(
         ansis.green(`\nFile "${finalFileName}" written to '${destPath}'.\n`),
       ),
-    ) //console.log()
+    )
     .catch((err) => console.error(`Error creating directory: ${err.message}`));
   try {
     fs.writeFile(`${destPath}/${finalFileName}`, content);

--- a/src/modules/createSvg/createSvg.ts
+++ b/src/modules/createSvg/createSvg.ts
@@ -29,12 +29,12 @@ async function createSvg(
     .mkdir(destPath, { recursive: true })
     .then(() =>
       stderr.write(
-        ansis.green(`\nFile "${fileName}" written to '${destPath}'.\n`),
+        ansis.green(`\nFile "${finalFileName}" written to '${destPath}'.\n`),
       ),
     ) //console.log()
     .catch((err) => console.error(`Error creating directory: ${err.message}`));
   try {
-    fs.writeFile(`${destPath}/${fileName}`, content);
+    fs.writeFile(`${destPath}/${finalFileName}`, content);
   } catch (err: unknown) {
     errorProcessing(err);
   }

--- a/src/modules/findNodes/filterForTime.ts
+++ b/src/modules/findNodes/filterForTime.ts
@@ -1,37 +1,16 @@
-import type { FeatureCollection, TimePeriod } from "@projectTypes/timeTypes";
-
-function findTimePeriod(validTime: TimePeriod): [number, number] {
-	const returnValue = [
-		validTime.begin.TimeInstant.timePosition,
-		validTime.end.TimeInstant.timePosition,
-	].map((time) => {
-		if (typeof time === "string") {
-			return 0;
-		}
-		return time;
-	});
-
-	return [returnValue[0], returnValue[1]];
-}
+import type { GPlates_Feature } from '@projectTypes/timeTypes';
 
 export function filterForTime(
-	sourceJsonArray: Record<string, unknown>[],
-	time: number,
-): FeatureCollection[] {
-	const filteredFeatures = sourceJsonArray
-		.flatMap((feature) => {
-			const keys = Object.keys(feature);
-			return keys.map((key) => {
-				const value = feature[key] as FeatureCollection;
-				value.featureType = key;
-				return value;
-			});
-		})
-		.filter((feature: FeatureCollection) => {
-			const [beginTime, endTime] = findTimePeriod(feature.validTime.TimePeriod);
-			// must have existed by the beginning time
-			return time <= beginTime && time >= endTime;
-		});
+  sourceJsonArray: GPlates_Feature[],
+  time: number,
+): GPlates_Feature[] {
+  const filteredFeatures = sourceJsonArray.filter(
+    (feature: GPlates_Feature) => {
+      const { begin, end } = feature.processedTime;
+      // must have existed by the beginning time
+      return time <= begin && time >= end;
+    },
+  );
 
-	return filteredFeatures;
+  return filteredFeatures;
 }

--- a/src/modules/findNodes/parseToJson.ts
+++ b/src/modules/findNodes/parseToJson.ts
@@ -1,29 +1,75 @@
-import { promises as fs } from "node:fs";
-import type { FeatureCollection } from "@projectTypes/timeTypes";
-import errorProcessing from "@utilities/errorProcessing";
-import { XMLParser } from "fast-xml-parser";
+import { promises as fs } from 'node:fs';
+import type { GPlates_Feature } from '@projectTypes/timeTypes';
+import errorProcessing from '@utilities/errorProcessing';
+import { XMLParser } from 'fast-xml-parser';
+
+export function stripGPML(data: string): string {
+  let strippedData = data.replace(/gml:/g, '');
+  strippedData = strippedData.replace(/gpml:/g, '');
+
+  return strippedData;
+}
+
+export function timeToNumber(value: string | number): number {
+  if (typeof value === 'string') {
+    if (value.includes('distantPast')) {
+      return Number.POSITIVE_INFINITY;
+    }
+    if (value.includes('distantFuture')) {
+      return 0;
+    }
+
+    return Number.parseFloat(value);
+  }
+
+  return value;
+}
 
 export async function parseToJson(
-	sourcePath: string,
-): Promise<Array<FeatureCollection> | undefined> {
-	try {
-		let data = await fs.readFile(sourcePath, "utf8");
-		data = data.replace(/gml:/g, "");
-		data = data.replace(/gpml:/g, "");
-		const parser = new XMLParser();
-		const parsedJson = parser.parse(data);
+  sourcePath: string,
+): Promise<Array<GPlates_Feature> | undefined> {
+  try {
+    let data = await fs.readFile(sourcePath, 'utf8');
+    data = stripGPML(data);
 
-		if (parsedJson?.FeatureCollection) {
-			const sourceJson = parsedJson.FeatureCollection;
-			if (Array.isArray(sourceJson.featureMember)) {
-				return sourceJson.featureMember;
-			}
-		}
+    const parser = new XMLParser();
+    const parsedJson = parser.parse(data);
 
-		// throw new Error(`No FeatureCollection found in ${sourcePath}`);
-		console.warn(`No FeatureCollection found in ${sourcePath}`);
-		return;
-	} catch (err: unknown) {
-		errorProcessing(err);
-	}
+    let featureCollectionArray: Array<Record<string, GPlates_Feature>> = [];
+
+    if (parsedJson?.FeatureCollection) {
+      const sourceJson = parsedJson.FeatureCollection;
+      if (Array.isArray(sourceJson.featureMember)) {
+        featureCollectionArray = [...sourceJson.featureMember];
+      } else if (typeof sourceJson.featureMember === 'object') {
+        featureCollectionArray = [sourceJson.featureMember];
+      }
+    }
+
+    if (featureCollectionArray.length < 1) {
+      console.warn(`No FeatureCollection found in ${sourcePath}`);
+      return;
+    }
+
+    return featureCollectionArray.flatMap((featureCollection) => {
+      const newCollection: Array<GPlates_Feature> = [];
+      for (const [key, gPFeature] of Object.entries(featureCollection)) {
+        gPFeature.featureType = key;
+        gPFeature.processedTime = {
+          begin: timeToNumber(
+            gPFeature.validTime.TimePeriod.begin.TimeInstant.timePosition,
+          ),
+          end: timeToNumber(
+            gPFeature.validTime.TimePeriod.end.TimeInstant.timePosition,
+          ),
+        };
+        newCollection.push(gPFeature);
+      }
+      return newCollection;
+    });
+
+    // return featureCollectionArray;
+  } catch (err: unknown) {
+    errorProcessing(err);
+  }
 }

--- a/src/modules/validFiles/validColorRamp.ts
+++ b/src/modules/validFiles/validColorRamp.ts
@@ -1,56 +1,56 @@
-import path from "node:path";
-import { stdout } from "node:process";
-import { select } from "@inquirer/prompts";
-import type { Choice } from "@projectTypes/Choice";
-import { findFileTypeInDirectory } from "@utilities/findFileTypeInDirectory";
-import { isDirectory } from "@utilities/isDirectory";
-import { isFile } from "@utilities/isFile";
-import { COLOR_RAMP_FILE_EXT } from "constants/GPLATES_CONSTANTS";
-import { jsonFromCpt } from "./jsonFromCpt";
+import path from 'node:path';
+import { stdout } from 'node:process';
+import { select } from '@inquirer/prompts';
+import type { Choice } from '@projectTypes/Choice';
+import { findFileTypeInDirectory } from '@utilities/findFileTypeInDirectory';
+import { isDirectory } from '@utilities/isDirectory';
+import { isFile } from '@utilities/isFile';
+import { COLOR_RAMP_FILE_EXT } from 'constants/GPLATES_CONSTANTS';
+import { jsonFromCpt } from './jsonFromCpt';
 
 function validCR(filePath: string) {
-	if (path.extname(filePath) !== COLOR_RAMP_FILE_EXT) {
-		console.warn("Invalid file name");
-		process.exit(1);
-	}
+  if (path.extname(filePath) !== COLOR_RAMP_FILE_EXT) {
+    console.warn('Invalid file name');
+    process.exit(1);
+  }
 
-	stdout.write(`Using ${filePath} as the color ramp.`);
+  stdout.write(`Using ${filePath} as the color ramp.`);
 
-	// process cpt and extract values
-	return jsonFromCpt(filePath);
+  // process cpt and extract values
+  return jsonFromCpt(filePath);
 }
 
 async function selectCPT(candidateNames: string[]): Promise<string> {
-	const choices: Choice<string>[] = candidateNames.map((name) => ({
-		value: name,
-	}));
+  const choices: Choice<string>[] = candidateNames.map((name) => ({
+    value: name,
+  }));
 
-	const fileName = await select({
-		message: "Which color ramp would you like to use?",
-		choices,
-	});
+  const fileName = await select({
+    message: 'Which color ramp would you like to use?',
+    choices,
+  });
 
-	return fileName;
+  return fileName;
 }
 
 export async function validColorRamp(filePath: string) {
-	if (isFile(filePath)) {
-		return await validCR(filePath);
-	}
+  if (isFile(filePath)) {
+    return await validCR(filePath);
+  }
 
-	if (isDirectory(filePath)) {
-		console.log("DIR");
-		const { cpt } = findFileTypeInDirectory(filePath, ["cpt"]);
-		if (cpt.length === 0) {
-			console.warn("No valid color ramp provided");
-			process.exit(1);
-		} else if (cpt.length === 1) {
-			return await validCR(path.join(filePath, cpt[0]));
-		} else {
-			const selectedCPT = await selectCPT(cpt);
-			return await validCR(path.join(filePath, selectedCPT));
-		}
-	}
+  if (isDirectory(filePath)) {
+    console.log('DIR');
+    const { cpt } = findFileTypeInDirectory(filePath, ['cpt']);
+    if (cpt.length === 0) {
+      console.warn('No valid color ramp provided');
+      process.exit(1);
+    } else if (cpt.length === 1) {
+      return await validCR(path.join(filePath, cpt[0]));
+    } else {
+      const selectedCPT = await selectCPT(cpt);
+      return await validCR(path.join(filePath, selectedCPT));
+    }
+  }
 
-	console.warn("NO VALID CR FOUND");
+  console.warn('NO VALID CR FOUND');
 }

--- a/src/types/timeTypes.ts
+++ b/src/types/timeTypes.ts
@@ -1,26 +1,32 @@
 export type TimeInstant = {
-	timePosition: number | string;
+  timePosition: number | string;
 };
 
 export type TimePeriod = {
-	begin: { TimeInstant: TimeInstant };
-	end: { TimeInstant: TimeInstant };
+  begin: { TimeInstant: TimeInstant };
+  end: { TimeInstant: TimeInstant };
 };
 
-export type FeatureCollection = {
-	identity: string;
-	revision: string;
-	name: string;
-	validTime: {
-		TimePeriod: TimePeriod;
-	};
-	geometryImportTime: TimeInstant;
-	reconstructionPlateId: {
-		ConstantValue: {
-			value: number;
-		};
-	};
-	// biome-ignore lint/complexity/noBannedTypes: <explanation>
-	outlineOf: {};
-	featureType: string;
+export type GPlates_Feature = {
+  identity: string;
+  revision: string;
+  name: string;
+  validTime: {
+    TimePeriod: TimePeriod;
+  };
+  processedTime: {
+    begin: number;
+    end: number;
+  };
+  geometryImportTime: TimeInstant;
+  reconstructionPlateId: {
+    ConstantValue: {
+      value: number;
+    };
+  };
+  // biome-ignore lint/complexity/noBannedTypes: <explanation>
+  outlineOf: {};
+  featureType: string;
 };
+
+export type FeatureCollection = Array<GPlates_Feature>;

--- a/src/utilities/colorProcessing.ts
+++ b/src/utilities/colorProcessing.ts
@@ -1,82 +1,82 @@
-import { stderr } from "node:process";
-import type { RgbColorArrayType } from "@modules/colorMap/createColorArray";
-import NAMED_COLORS from "../constants/NAMED_COLORS";
+import { stderr } from 'node:process';
+import type { RgbColorArrayType } from '@modules/colorMap/createColorArray';
+import NAMED_COLORS from '../constants/NAMED_COLORS';
 
 const HexColorRegex = /^#?([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
 const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
 
 // CREDIT WHERE CREDIT IS DUE: https://stackoverflow.com/a/5624139
 export function hexToRgb(hex: string): RgbColorArrayType | undefined {
-	if (!HexColorRegex.test(hex) && !shorthandRegex.test(hex)) {
-		stderr.write(`Color ${hex} is not valid. Defaulting to gray.`);
-		return [128, 128, 128];
-	}
+  if (!HexColorRegex.test(hex) && !shorthandRegex.test(hex)) {
+    stderr.write(`Color ${hex} is not valid. Defaulting to gray.`);
+    return [128, 128, 128];
+  }
 
-	// Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
-	const testedHex = hex.replace(
-		shorthandRegex,
-		(_, r, g, b) => r + r + g + g + b + b,
-	);
+  // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
+  const testedHex = hex.replace(
+    shorthandRegex,
+    (_, r, g, b) => r + r + g + g + b + b,
+  );
 
-	const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(testedHex);
-	if (result) {
-		return [
-			Number.parseInt(result[1], 16), // red
-			Number.parseInt(result[2], 16), // green
-			Number.parseInt(result[3], 16), // blue
-		];
-	}
-	return;
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(testedHex);
+  if (result) {
+    return [
+      Number.parseInt(result[1], 16), // red
+      Number.parseInt(result[2], 16), // green
+      Number.parseInt(result[3], 16), // blue
+    ];
+  }
+  return;
 }
 
 export function componentToHex(colorValue: number) {
-	const clampedColorValue = Math.round(Math.max(0, Math.min(colorValue, 255)));
-	const hex = clampedColorValue.toString(16);
-	return hex.length === 1 ? `0${hex}` : hex;
+  const clampedColorValue = Math.round(Math.max(0, Math.min(colorValue, 255)));
+  const hex = clampedColorValue.toString(16);
+  return hex.length === 1 ? `0${hex}` : hex;
 }
 
 export function rgbToHex(rgbNumber: [number, number, number]): string {
-	const result = `#${rgbNumber.map((num) => componentToHex(num)).join("")}`;
-	if (!HexColorRegex.test(result)) {
-		stderr.write(`Color ${result} is not valid. Defaulting to gray.`);
-		return "#808080";
-	}
+  const result = `#${rgbNumber.map((num) => componentToHex(num)).join('')}`;
+  if (!HexColorRegex.test(result)) {
+    stderr.write(`Color ${result} is not valid. Defaulting to gray.`);
+    return '#808080';
+  }
 
-	return result;
+  return result;
 }
 
 export function colorValidation(color: string): string {
-	if (color.length < 1) {
-		return "";
-	}
+  if (color?.length < 1) {
+    return '';
+  }
 
-	if (NAMED_COLORS[color] !== undefined) {
-		return color;
-	}
+  if (NAMED_COLORS[color] !== undefined) {
+    return color;
+  }
 
-	if (!HexColorRegex.test(color) && !shorthandRegex.test(color)) {
-		stderr.write(`Color ${color} is not valid. Defaulting to no color.`);
-		("");
-	} else {
-		return color.charAt(0) === "#" ? color : `#${color}`;
-	}
+  if (!HexColorRegex.test(color) && !shorthandRegex.test(color)) {
+    stderr.write(`Color ${color} is not valid. Defaulting to no color.`);
+    ('');
+  } else {
+    return color.charAt(0) === '#' ? color : `#${color}`;
+  }
 
-	return "";
+  return '';
 }
 
 export default function colorProcessing(color: string): RgbColorArrayType {
-	if (NAMED_COLORS[color] !== undefined) {
-		return NAMED_COLORS[color] as RgbColorArrayType;
-	}
+  if (NAMED_COLORS[color] !== undefined) {
+    return NAMED_COLORS[color] as RgbColorArrayType;
+  }
 
-	if (HexColorRegex.test(color)) {
-		let formattedColor = color;
-		if (color.charAt(0) !== "#") {
-			formattedColor = `#${color}`;
-		}
-		return hexToRgb(formattedColor) as RgbColorArrayType;
-	}
+  if (HexColorRegex.test(color)) {
+    let formattedColor = color;
+    if (color.charAt(0) !== '#') {
+      formattedColor = `#${color}`;
+    }
+    return hexToRgb(formattedColor) as RgbColorArrayType;
+  }
 
-	stderr.write("Invalid color. Defaulting to gray.");
-	return [128, 128, 128];
+  stderr.write('Invalid color. Defaulting to gray.');
+  return [128, 128, 128];
 }


### PR DESCRIPTION
Debugged a lot
- fallback for border color if not provided
- fixed the problem when a feature has either a beginning in the distant past or an end in the distant future (or both)
- updated help with a paragraph and some fancy color

fixed one test now that the math is more exact.
updated the package so that help text doesn't show `index` as the starting point.